### PR TITLE
Fix commit button order in "Settings" window

### DIFF
--- a/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
+++ b/src/SyncTrayzor/Pages/Settings/SettingsView.xaml
@@ -24,8 +24,8 @@
     </Window.Resources>
     <DockPanel Margin="0,10">
         <StackPanel DockPanel.Dock="Bottom" Margin="0,10,10,0" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button IsCancel="True" Command="{s:Action Cancel}" Content="{l:Loc Generic_Dialog_Cancel}" Style="{StaticResource DialogButton}"/>
             <Button IsDefault="True" Command="{s:Action Save}" Content="{l:Loc Generic_Dialog_Save}" Style="{StaticResource DialogButton}"/>
+            <Button IsCancel="True" Command="{s:Action Cancel}" Content="{l:Loc Generic_Dialog_Cancel}" Style="{StaticResource DialogButton}"/>
         </StackPanel>
 
         <TabControl Background="Transparent" BorderThickness="0,1,0,0" SelectedIndex="{Binding SelectedTabIndex}">


### PR DESCRIPTION
follows Windows guidelines
https://msdn.microsoft.com/en-us/library/windows/desktop/dn742499(v=vs.85).aspx
"Present the commit buttons in the following order:
OK/[Do it]/Yes
[Don't do it]/No
Cancel
Apply (if present)
Help (if present)"